### PR TITLE
Fixed wrong php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It is heavily inspired on apiato wich is unfortunately abondoned and not up to d
 Why!? Because setting up a solid API from scratch is time consuming (and of course, time is money!). Larapie gives you the core features of robust API's fully documented, for free; so you can focus on writing your business logic, thus deliver faster to your clients.
 
 ### Requirements
-- Php >= 7.1
+- Php > 7.1
 - PHP Extensions: OpenSSL, PDO, Mbstring, Tokenizer
 - Composer
 - Webserver (nginx, apache, lightspeed, ..)


### PR DESCRIPTION
I run command `composer create-project larapie/larapie -vvv` on my MBP, But Composer throw exception:
```bash
[InvalidArgumentException]
  Could not find package larapie/larapie with stability stable in a version installable using your PHP version 7.1.23  .
```

So. I switch php version to v7.2, and it' worked!